### PR TITLE
feat: Add build scripts and instructions for Windows installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# PyInstaller
+/dist/
+/build/
+*.spec
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Other
+.DS_Store

--- a/release/HOW_TO_USE.md
+++ b/release/HOW_TO_USE.md
@@ -1,0 +1,50 @@
+# How to Build and Install Selene on Windows
+
+This guide provides step-by-step instructions to compile the Selene application and create a Windows installer.
+
+## Prerequisites
+
+Before you begin, you need to install the following software on your Windows machine:
+
+1.  **Python:** Download and install the latest version of Python from the [official website](https://www.python.org/downloads/windows/). Make sure to check the box **"Add Python to PATH"** during installation.
+
+2.  **PyInstaller:** This tool packages the Python application into a standalone executable. Open a Command Prompt (cmd) or PowerShell and run the following command:
+    ```
+    pip install pyinstaller
+    ```
+
+3.  **NSIS (Nullsoft Scriptable Install System):** This tool creates the installer. Download and install NSIS from the [official website](https://nsis.sourceforge.io/Download).
+
+## Step 1: Prepare the Icon
+
+The build script requires the application icon to be in the `.ico` format.
+
+1.  The project's logo is located at `Functions/luna/Assets/icono.png`. You need to convert this file to an `.ico` file named `icono.ico`. You can use a free online converter for this (e.g., search for "PNG to ICO converter").
+2.  Once you have the `icono.ico` file, place it in the same `Functions/luna/Assets/` directory.
+
+## Step 2: Build the Executable
+
+The `build.py` script automates the process of creating the `Selene.exe` executable.
+
+1.  Open a Command Prompt or PowerShell.
+2.  Navigate to the root directory of the Selene project.
+3.  Run the build script using the following command:
+    ```
+    python release/build.py
+    ```
+4.  If the build is successful, a `dist` directory will be created in the project root, containing `Selene.exe`.
+
+## Step 3: Create the Installer
+
+The `installer.nsi` script uses NSIS to package `Selene.exe` into a user-friendly installer.
+
+1.  Right-click on the `release/installer.nsi` file.
+2.  Select **"Compile NSIS Script"** from the context menu. This option will be available if you installed NSIS correctly.
+3.  NSIS will compile the script, and if successful, it will create `Selene_Installer.exe` in the `release` directory.
+
+## Step 4: Run the Installer
+
+You can now run `Selene_Installer.exe` to install the Selene application on your system. The installer will create a shortcut in the Start Menu for easy access.
+
+---
+If you encounter any issues, please ensure that all prerequisites are installed correctly and that you are running the commands from the project's root directory.

--- a/release/build.py
+++ b/release/build.py
@@ -1,0 +1,52 @@
+import subprocess
+import os
+import sys
+
+def main():
+    """
+    Compiles the Selene project into a single executable for Windows.
+    This script should be run from the project's root directory.
+    e.g., python release/build.py
+    """
+    # Ensure the script is run from the project root
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    if os.getcwd() != project_root:
+        print(f"Changing current directory to project root: {project_root}")
+        os.chdir(project_root)
+
+    icon_path_png = os.path.join('Functions', 'luna', 'Assets', 'icono.png')
+    icon_path_ico = os.path.join('Functions', 'luna', 'Assets', 'icono.ico')
+
+    # PyInstaller on Windows requires an .ico file.
+    # We check for it and provide instructions if it's missing.
+    if not os.path.exists(icon_path_ico):
+        print(f"Error: Icon file '{icon_path_ico}' not found.")
+        print(f"Please convert '{icon_path_png}' to a .ico file and place it in the same directory.")
+        print("There are free online tools available to convert PNG to ICO.")
+        sys.exit(1)
+
+    # Command to build the executable
+    command = [
+        'pyinstaller',
+        '--onefile',
+        '--name', 'Selene',
+        '--icon', icon_path_ico,
+        'selene.py'
+    ]
+
+    print(f"Running command: {' '.join(command)}")
+
+    try:
+        # Run the command from the project root
+        subprocess.run(command, check=True, cwd=project_root)
+        print("\nBuild successful! The executable can be found in the 'dist' directory.")
+    except subprocess.CalledProcessError as e:
+        print(f"\nBuild failed with error: {e}")
+        sys.exit(1)
+    except FileNotFoundError:
+        print("\nError: 'pyinstaller' command not found.")
+        print("Please make sure PyInstaller is installed (`pip install pyinstaller`).")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/release/installer.nsi
+++ b/release/installer.nsi
@@ -1,0 +1,86 @@
+; NSIS Script for Selene Installer
+; This script should be compiled on a Windows machine with NSIS installed.
+; It assumes that the 'Selene.exe' executable has been built and is
+; located in the '../dist' directory relative to this script.
+
+;--------------------------------
+; Application Details
+;--------------------------------
+
+!define APP_NAME "Selene"
+!define APP_VERSION "1.0"
+!define PUBLISHER "Selene Project"
+!define EXE_NAME "Selene.exe"
+!define INSTALLER_NAME "Selene_Installer.exe"
+!define ICON_FILE "..\Functions\luna\Assets\icono.ico"
+!define UNINSTALL_ICON_FILE "..\Functions\luna\Assets\icono.ico"
+
+;--------------------------------
+; Installer Configuration
+;--------------------------------
+
+; Name of the installer
+OutFile "${INSTALLER_NAME}"
+
+; Default installation directory
+InstallDir "$PROGRAMFILES\${APP_NAME}"
+
+; Set the icon for the installer
+Icon "${ICON_FILE}"
+UninstallIcon "${UNINSTALL_ICON_FILE}"
+
+; Request admin privileges for installation
+RequestExecutionLevel admin
+
+;--------------------------------
+; Pages
+;--------------------------------
+
+Page directory
+Page instfiles
+
+UninstPage uninstConfirm
+UninstPage instfiles
+
+;--------------------------------
+; Installation Section
+;--------------------------------
+
+Section "Install"
+
+  ; Set output path to the installation directory
+  SetOutPath $INSTDIR
+
+  ; Add the main executable
+  ; The file is expected to be in the 'dist' folder, one level up
+  File "..\dist\${EXE_NAME}"
+
+  ; Create the uninstaller
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+
+  ; Create Start Menu shortcuts
+  CreateDirectory "$SMPROGRAMS\${APP_NAME}"
+  CreateShortCut "$SMPROGRAMS\${APP_NAME}\${APP_NAME}.lnk" "$INSTDIR\${EXE_NAME}"
+  CreateShortCut "$SMPROGRAMS\${APP_NAME}\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
+
+SectionEnd
+
+;--------------------------------
+; Uninstallation Section
+;--------------------------------
+
+Section "Uninstall"
+
+  ; Remove files
+  Delete "$INSTDIR\${EXE_NAME}"
+  Delete "$INSTDIR\Uninstall.exe"
+
+  ; Remove Start Menu shortcuts
+  Delete "$SMPROGRAMS\${APP_NAME}\${APP_NAME}.lnk"
+  Delete "$SMPROGRAMS\${APP_NAME}\Uninstall.lnk"
+  RMDir "$SMPROGRAMS\${APP_NAME}"
+
+  ; Remove the installation directory
+  RMDir "$INSTDIR"
+
+SectionEnd


### PR DESCRIPTION
This commit introduces a complete workflow for creating a Windows installer for the Selene application.

Since direct cross-compilation from the development environment is not feasible, this solution empowers the user to build the installer on a native Windows machine.

Key additions:
- A `build.py` script that uses PyInstaller to compile `selene.py` into a single executable.
- An `installer.nsi` script for the Nullsoft Scriptable Install System (NSIS) to create a professional installer.
- A detailed `HOW_TO_USE.md` file with step-by-step instructions for setting up the environment and running the build process.
- A `.gitignore` file to exclude build artifacts from version control.

All new files are organized within a `release` directory.